### PR TITLE
add default host into router

### DIFF
--- a/packages/nodos-routing/lib/Router.js
+++ b/packages/nodos-routing/lib/Router.js
@@ -257,6 +257,7 @@ class Router {
   constructor(routeMap, options) {
     validate(routeMap);
 
+    // TODO: temporary solution with setting default host. We have to pass it from env configs
     this.host = options.host ?? 'example.com';
     this.routeMap = routeMap;
     this.scopes = routeMap.scopes.map(({ name, pipeline }) => ({

--- a/packages/nodos-routing/lib/Router.js
+++ b/packages/nodos-routing/lib/Router.js
@@ -257,7 +257,7 @@ class Router {
   constructor(routeMap, options) {
     validate(routeMap);
 
-    this.host = options.host;
+    this.host = options.host ?? 'example.com';
     this.routeMap = routeMap;
     this.scopes = routeMap.scopes.map(({ name, pipeline }) => ({
       name,


### PR DESCRIPTION
Currently, we are getting errors when we try to start an example app in the package. The reason is we are not passing `host` param as an option into Router and `path.join` can't work with `undefined`. It is a temporary solution because we need to pass this param from environment configurations