### PR TITLE
fix render in class Response

### DIFF
--- a/packages/nodos-core/lib/http/Response.js
+++ b/packages/nodos-core/lib/http/Response.js
@@ -94,8 +94,10 @@ class Response {
    */
   render(locals = {}, template = this.templateName) {
     this.responseType = 'rendering';
-    // FIXME: check if property already exists
-    Object.assign(this.locals, locals);
+    const self = this;
+    _.forEach(locals, function (value, key) {
+      self.addLocal(key, value);
+    });
     this.templateName = template;
   }
 


### PR DESCRIPTION
before: 
`render(locals = {}, template = this.templateName) {
    this.responseType = 'rendering';
    // FIXME: check if property already exists
    Object.assign(this.locals, locals);
    this.templateName = template;
  }`
after:
`render(locals = {}, template = this.templateName) {
    this.responseType = 'rendering';
    const self = this;
    _.forEach(locals, function (value, key) {
      self.addLocal(key, value);
    });
    this.templateName = template;
  }`