### PR TITLE
fix Response.render

### DIFF
--- a/packages/nodos-core/lib/http/Response.js
+++ b/packages/nodos-core/lib/http/Response.js
@@ -94,8 +94,8 @@ class Response {
    */
   render(locals = {}, template = this.templateName) {
     this.responseType = 'rendering';
-    // FIXME: check if property already exists
-    Object.assign(this.locals, locals);
+    const self = this;
+    Object.entries(locals).forEach(([key, value]) => self.addLocal(key, value));
     this.templateName = template;
   }
 


### PR DESCRIPTION
before:
```
render(locals = {}, template = this.templateName) {
    this.responseType = 'rendering';
    // FIXME: check if property already exists
    Object.assign(this.locals, locals);
    this.templateName = template;
  }
```
after:
```
render(locals = {}, template = this.templateName) {
    this.responseType = 'rendering';
    const self = this;
    Object.entries(locals).forEach(([key, value]) => self.addLocal(key, value));
    this.templateName = template;
  }
```