### PR TITLE
[#169] Add(example/.eslintrc.yml) rule. Ignore unused vars beginning with underscore and only the last argument must be used

### DIFF
--- a/example/.eslintrc.yml
+++ b/example/.eslintrc.yml
@@ -23,4 +23,6 @@ extends:
 
 rules:
   no-console: 0
-
+  no-unused-vars:
+    - 2
+    - argsIgnorePattern: ^_


### PR DESCRIPTION
Не стал добавлять "args": "after-used", так как эта настройка установленно по умолчанию (https://eslint.org/docs/2.0.0/rules/no-unused-vars#args).

