### PR TITLE
fix init command

### DIFF
--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -13,7 +13,7 @@ sudo apt-get install -y nodejs
 ## Step 2: Generate a new project
 
 ```sh
-npx init @nodosjs projectName 
+npm init @nodosjs projectName 
 ```
 
 This command performs next actions:


### PR DESCRIPTION
При запуске через `npx init` получаем ошибку 
```bash
npm ERR! could not determine executable to run
```