### PR TITLE
lock middie 5.2.0 for example

### DIFF
--- a/packages/nodos-cli/lib/templates/generate/new/package.json.t
+++ b/packages/nodos-cli/lib/templates/generate/new/package.json.t
@@ -24,7 +24,8 @@ to: './<%= name %>/package.json'
     "@nodosjs/view-extension": "^<%= version %>",
     "@nodosjs/webpack-extension": "^<%= version %>",
     "sql.js": "^1.5.0",
-    "pg": "^8.5.1"
+    "pg": "^8.5.1",
+    "middie": "5.2.0"
   },
   "devDependencies": {
     "@nodosjs/jest-environment": "^<%= version %>",


### PR DESCRIPTION
Middie обновился до 5.3.0 версии, теперь в этом пакете используется по дефолту use декоратор, но он также используется в фастифае, в результате ломается

Чтот непонятно, как тут лучше мержить/пушить, если я делаю от старого релиза ветку.